### PR TITLE
Update Cargo.toml copyright

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright 2014 Benjamin Elder.
+# Copyright 2014-2016 Benjamin Elder (BenTheElder) and the slack-rs authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update to current year and to include "the slack-rs authors" (namely Matt Jones @mthjones, who is currently listed as an author in the package settings).