### PR TITLE
Update repo and docs URLs in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "slack"
 version = "0.13.0"
 authors = ["Benjamin Elder <bentheelder@gmail.com>", "Matt Jones <mthjones@gmail.com>"]
-repository = "https://github.com/BenTheElder/slack-rs.git"
-documentation = "https://bentheelder.github.io/slack-rs"
+repository = "https://github.com/slack-rs/slack-rs.git"
+documentation = "http://slack-rs.github.io/slack-rs/slack/index.html"
 description = "slack realtime messaging client: https://api.slack.com/bot-users"
 license = "Apache-2.0"
 


### PR DESCRIPTION
The old repo link still redirects to the new one, but the docs linked from crates.io are 404.