### PR TITLE
Changing &Event to Event in on_event().

### DIFF
--- a/examples/slack_example.rs
+++ b/examples/slack_example.rs
@@ -27,7 +27,7 @@ struct MyHandler;
 
 #[allow(unused_variables)]
 impl slack::EventHandler for MyHandler {
-    fn on_event(&mut self, cli: &mut slack::RtmClient, event: Result<&slack::Event, slack::Error>, raw_json: &str) {
+    fn on_event(&mut self, cli: &mut slack::RtmClient, event: Result<slack::Event, slack::Error>, raw_json: &str) {
         println!("on_event(event: {:?}, raw_json: {:?})", event, raw_json);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub type WsClient = Client<websocket::dataframe::DataFrame,
 pub trait EventHandler {
     /// When a message is received this will be called with self, the slack client,
     /// and the result of parsing the event received, as well as the raw json string.
-    fn on_event(&mut self, cli: &mut RtmClient, event: Result<&Event, Error>, raw_json: &str);
+    fn on_event(&mut self, cli: &mut RtmClient, event: Result<Event, Error>, raw_json: &str);
 
     /// Called when a ping is received; you do NOT need to handle the reply pong,
     /// but you may use this event to track the connection as a keep-alive.
@@ -434,7 +434,7 @@ impl RtmClient {
                 WsType::Text => {
                     let raw_string : String = try!(String::from_utf8(message.payload.into_owned()));
                     match json::decode(&raw_string) {
-                        Ok(event) => handler.on_event(self, Ok(&event), &raw_string),
+                        Ok(event) => handler.on_event(self, Ok(event), &raw_string),
                         Err(err) => handler.on_event(self, Err(Error::JsonDecode(err)), &raw_string),
                     }
                 }


### PR DESCRIPTION
I am aware that this breaks backwards compatibility, so this can be discussed whether this should be changed as brutally as it's done now. However, is there a reason new events are not passed to the handler by value instead ? Being an immutable reference leaves the handler unable to decompose any of the events. 
This implies that I cannot do `self.ids_to_nicks.insert(user.id, user.name)` as I have to do `self.ids_to_nicks.insert(user.id.clone(), user.name.copy())`.
Since the actual event enum is only ever passed to the handler and never referenced, ever again, it has no reason to be passed to the handler as a read-only reference. The handler, whatever it may be, should be mature enough to take ownership of the event at that point. 
I think it would be reasonable to change the interface of the library and increment the version number so no breakage ensues and users of the newer library can enjoy a more flexible interface. 
https://github.com/slack-rs/slack-rs/blob/257770fc1541c5693d27fedcfbb21543dd307d49/src/lib.rs#L500

Of course, if there are any future plans to do something with the Event enum later on, feel free to disregard this pull request. But I'd love to hear what these future plans would be.
