### PR TITLE
remove EAGAIN loop for being problematic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -465,13 +465,6 @@ impl RtmClient {
             let message : WebSocketMessage = match message_result {
                 Ok(message) => message,
                 Err(err) => {
-                    // If error is equivalent of EAGAIN, just loop
-                    if let WebSocketError::IoError(ref io_err) = err {
-                        if io_err.kind() == io::ErrorKind::WouldBlock {
-                            continue
-                        }
-                    }
-
                     // shutdown sender and receiver, then join the child thread
                     // and return an error.
                     let _ = tx.send(WsMessage::Close);


### PR DESCRIPTION
websocket library isn't warning of dead websocket properly resulting in infinite loop. easiest escape for now is avoid infinite loop!