### PR TITLE
Extend example with Web API usage

### DIFF
--- a/examples/slack_example.rs
+++ b/examples/slack_example.rs
@@ -22,9 +22,11 @@
 //
 
 extern crate slack;
-use slack::{Event, RtmClient};
+use slack::{Event, RtmClient, api};
 
-struct MyHandler;
+struct MyHandler {
+    token: String
+}
 
 #[allow(unused_variables)]
 impl slack::EventHandler for MyHandler {
@@ -52,8 +54,19 @@ impl slack::EventHandler for MyHandler {
                       })
             .and_then(|chan| chan.id.as_ref())
             .expect("general channel not found");
-        let _ = cli.sender().send_message(&general_channel_id, "Hello world! (rtm)");
+
         // Send a message over the real time api websocket
+        let _ = cli.sender().send_message(&general_channel_id, "Hello world! (rtm)");
+
+        // Send a message via the HTTP Web API (supports full formatting options and attachments)
+        // NOTE: Using the reqwest version re-exported by slack::api. Using reqwest directly might fail
+        // if the versions are mismatched (because of the SlackWebRequestSender trait impl)
+        let client = api::requests::reqwest::Client::new().unwrap();
+        let _ = api::chat::post_message(&client, &self.token, &api::chat::PostMessageRequest {
+            channel: &general_channel_id,
+            text: "Hello world! (<https://slack-rs.github.io/slack-rs/slack_api/chat/fn.post_message.html|Web API>)",
+            ..api::chat::PostMessageRequest::default()
+        });
     }
 }
 
@@ -63,7 +76,7 @@ fn main() {
         0 | 1 => panic!("No api-key in args! Usage: cargo run --example slack_example -- <api-key>"),
         x => args[x - 1].clone(),
     };
-    let mut handler = MyHandler;
+    let mut handler = MyHandler { token: api_key.clone() };
     let r = RtmClient::login_and_run(&api_key, &mut handler);
     match r {
         Ok(_) => {}


### PR DESCRIPTION
Using the Web API can be a bit tricky (see #81), so an example might help...
Depends on slack-rs/slack-rs-api#42