### PR TITLE
Shorten read timeout, and allow WouldBlock as a sign to try again later

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,19 +217,15 @@ impl RtmClient {
             // blocks until a message is received, websocket errors, or a read timeout occurs
             let message = match websocket.read_message() {
                 Ok(msg) => msg,
-                Err(Io(x)) => {
-                    // Allow WouldBlock errors to keep the show moving
-                    if x.kind() == WouldBlock {
-                        continue
-                    }
 
-                    // Other IoErrors not acceptable
-                    return Err(x.into());
+                // Allow WouldBlock errors to keep the show moving
+                Err(Io(ref x)) if x.kind() == WouldBlock => {
+                    continue
                 }
 
-                // Any other socket error not acceptable
-                Err(y) => {
-                    return Err(y.into());
+                // Any other error not acceptable
+                Err(e) => {
+                    return Err(e.into());
                 }
             };
 


### PR DESCRIPTION
Hey,

After looking at the problem with fresh eyes, I realized that it is possible to reduce the timeout, and gracefully handle them (signified by `WouldBlock` errors).

I have tested this locally, and it works for my case. I thought I would offer it back if you are interested. Tests still pass.

I am less familiar with Websockets, so if we *should* fail if a read takes longer than 70 seconds, please let me know, and I can implement a "timeout counter" to prevent too many subsequent timeouts. Also no worries if you would prefer to just have async "sends" only be sent though the API (rather than RTM), though it was surprising to me that this didn't work before.