### PR TITLE
Timeout problems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ slack_api = { version = "0.18.0", features = ["reqwest"] }
 serde = "1.0.0"
 serde_json = "1.0.0"
 serde_derive = "1.0.0"
-tungstenite = "0.2.0"
+tungstenite = "0.5.3"
 log = "0.3.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ impl RtmClient {
             .ok_or(Error::Api("Slack did not provide a URL".into()))?;
 
         let wss_url = reqwest::Url::parse(&start_url)?;
-        let mut websocket = tungstenite::connect(wss_url)?;
+        let (mut websocket, _resp) = tungstenite::client::connect(wss_url)?;
 
         // Slack can leave us hanging
         {
@@ -226,7 +226,15 @@ impl RtmClient {
                         }
                     }
                 }
-                tungstenite::Message::Binary(_) => {}
+                tungstenite::Message::Binary(_) => {
+                    debug!("RTM WS Binary recieved");
+                }
+                tungstenite::Message::Ping(_) => {
+                    debug!("RTM WS Ping recieved");
+                }
+                tungstenite::Message::Pong(_) => {
+                    debug!("RTM WS Ping recieved");
+                }
             }
         }
     }


### PR DESCRIPTION
slack have changed their ping timeout it would seem from 60 seconds to 120 seconds.
This is my attempt to do away with depending on their timeout to decide if they disconnected or not.
So the idea is have timeout at something reasonable (30 seconds) and if there's an error try send a ping to confirm if we're dead or not. If the ping fails then we're dead.
fixes #100