### PR TITLE
Presence subscriptions

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -171,7 +171,7 @@ pub enum Event {
     },
     /// Represents the slack
     /// [`presence_change`](https://api.slack.com/events/presence_change) event.
-    PresenceChange { user: String, presence: String },
+    PresenceChange { user: Option<String>, users: Option<Box<Vec<String>>>, presence: String },
     /// Represents the slack
     /// [`manual_presence_change`](https://api.slack.com/events/manual_presence_change) event.
     ManualPresenceChange { presence: String },
@@ -381,6 +381,52 @@ mod tests {
                 assert_eq!(code, 2);
                 assert_eq!(msg, "message text is missing");
             }
+            _ => panic!("Event decoded into incorrect variant."),
+        }
+    }
+
+    #[test]
+    fn decode_presence_change_event() {
+        let event: Event = Event::from_json(r##"{
+            "type": "presence_change",
+            "users": ["U024BE7LH", "U012EA2U1"],
+            "presence": "away"
+        }"##)
+                .unwrap();
+        match event {
+            Event::PresenceChange{users, presence, ..} => {
+                assert_eq!(presence, "away");
+                match users {
+                    Some(u) => {
+                        assert_eq!(u.len(), 2);
+                        assert_eq!(u[0], "U024BE7LH");
+                        assert_eq!(u[1], "U012EA2U1");
+                    },
+                    _ => panic!("Presence change does not contain users elem"),
+                }
+            },
+            _ => panic!("Event decoded into incorrect variant."),
+        }
+    }
+
+    #[test]
+    fn decode_legacy_presence_change_event() {
+        let event: Event = Event::from_json(r##"{
+            "type": "presence_change",
+            "user": "U024BE7LH",
+            "presence": "away"
+        }"##)
+                .unwrap();
+        match event {
+            Event::PresenceChange{user, presence, ..} => {
+                assert_eq!(presence, "away");
+                match user {
+                    Some(u) => {
+                        assert_eq!(u, "U024BE7LH");
+                    },
+                    _ => panic!("Presence change does not contain users elem"),
+                }
+            },
             _ => panic!("Event decoded into incorrect variant."),
         }
     }

--- a/src/events.rs
+++ b/src/events.rs
@@ -171,7 +171,7 @@ pub enum Event {
     },
     /// Represents the slack
     /// [`presence_change`](https://api.slack.com/events/presence_change) event.
-    PresenceChange { user: Option<String>, users: Option<Box<Vec<String>>>, presence: String },
+    PresenceChange { user: Option<String>, users: Option<Vec<String>>, presence: String },
     /// Represents the slack
     /// [`manual_presence_change`](https://api.slack.com/events/manual_presence_change) event.
     ManualPresenceChange { presence: String },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,9 +190,10 @@ impl RtmClient {
             .url
             .as_ref()
             .ok_or(Error::Api("Slack did not provide a URL".into()))?;
-        println!("start_url returned is \"{:?}\"", start_url);
-
-        let wss_url = reqwest::Url::parse(&start_url)?;
+        let mut start_url_qp = start_url.clone();
+        start_url_qp.push_str(&("?batch_presence_aware=1".to_string()));
+        println!("start_url returned is \"{:?}\"", start_url_qp);
+        let wss_url = reqwest::Url::parse(&start_url_qp)?;
         let (mut websocket, _resp) = tungstenite::client::connect(wss_url)?;
 
         // Slack can leave us hanging

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,25 @@ impl Sender {
         Ok(n)
     }
 
+    /// Subscribes to presence updates for the given users
+    /// This is due to the update in presence events detailed here:
+    /// https://api.slack.com/changelog/2017-10-making-rtm-presence-subscription-only
+    ///
+    /// `user_list` is a slice of the list of users to subscrib, e.g. `W839208`, not @xyz.
+    /// The full list of users to subscribe to must be sent each time the subscription should
+    /// change
+    /// Slack doc can be found at https://api.slack.com/docs/presence-and-status under "Determining
+    /// user presence"
+    pub fn subscribe_presence(&self, user_list: &[&str]) -> Result<usize, Error> {
+        let n = self.get_msg_uid();
+        let mstr = format!(r#"{{"type": "presence_sub", "ids": "{:?}"}}"#,
+                           user_list);
+
+        self.send(&mstr)
+            .map_err(|err| Error::Internal(format!("{:?}", err)))?;
+        Ok(n)
+    }
+
     /// Shutdown `RtmClient`
     pub fn shutdown(&self) -> Result<(), Error> {
         self.tx

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,7 @@ impl RtmClient {
             .url
             .as_ref()
             .ok_or(Error::Api("Slack did not provide a URL".into()))?;
+        println!("start_url returned is \"{:?}\"", start_url);
 
         let wss_url = reqwest::Url::parse(&start_url)?;
         let (mut websocket, _resp) = tungstenite::client::connect(wss_url)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ impl Sender {
     /// user presence"
     pub fn subscribe_presence(&self, user_list: &[&str]) -> Result<usize, Error> {
         let n = self.get_msg_uid();
-        let mstr = format!(r#"{{"type": "presence_sub", "ids": "{:?}"}}"#,
+        let mstr = format!(r#"{{"type": "presence_sub", "ids": {:?}}}"#,
                            user_list);
 
         self.send(&mstr)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,6 @@ impl RtmClient {
             .ok_or(Error::Api("Slack did not provide a URL".into()))?;
         let mut start_url_qp = start_url.clone();
         start_url_qp.push_str(&("?batch_presence_aware=1".to_string()));
-        println!("start_url returned is \"{:?}\"", start_url_qp);
         let wss_url = reqwest::Url::parse(&start_url_qp)?;
         let (mut websocket, _resp) = tungstenite::client::connect(wss_url)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,9 +190,7 @@ impl RtmClient {
             .url
             .as_ref()
             .ok_or(Error::Api("Slack did not provide a URL".into()))?;
-        let mut start_url_qp = start_url.clone();
-        start_url_qp.push_str(&("?batch_presence_aware=1".to_string()));
-        let wss_url = reqwest::Url::parse(&start_url_qp)?;
+        let wss_url = reqwest::Url::parse_with_params(&start_url, &[("batch_presence_aware", "1")])?;
         let (mut websocket, _resp) = tungstenite::client::connect(wss_url)?;
 
         // Slack can leave us hanging


### PR DESCRIPTION
I fixed the presence events for slack-rs, since slack has changed them as of Jan 2018.  This is related to issue https://github.com/slack-rs/slack-rs/issues/98.  I have written some tests, the old presence events will work as well as the new ones.  The only place where I am unsure if I took the right approach is that a query param of `batch_presence_aware=1` must be used with the wss url on connection to get events.  I don't know if this is something that should be added to the URL before parsing as I did it, or added to the parsed URL after.  Please let me know, I'm happy to update the PR.