### PR TITLE
Add Goodbye enum Event when RTM websocket duration exceeds 8 hours

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -83,6 +83,8 @@ pub enum Event {
         ts: String,
         event_ts: String,
     },
+    /// Represents the slack [`goodbye`](https://api.slack.com/events/goodbye) event.
+    Goodbye,
     /// Represents the slack
     /// [`group_joined`](https://api.slack.com/events/group_joined) event.
     GroupJoined { channel: Box<Channel> },


### PR DESCRIPTION
This PR adds the `goodbye` event defined here: https://api.slack.com/events/goodbye

Was seeing the below error on my server logs:
```
2020-08-19 01:45:11,545 INFO  [slackrypt_server::slack] on_connect
2020-08-19 01:46:18,071 INFO  [actix_web::middleware::logger] 127.0.0.1:42172 "GET /init.sh HTTP/1.0" 200 101 "-" "curl/7.58.0" 0.000096
2020-08-19 09:49:34,964 INFO  [slack] Unable to deserialize slack message, error: Json Error: Error("unknown variant `goodbye`, expected one of `hello`, `message`, `user_typing`, `channel_marked`, `channel_created`, `channel_joined`, `channel_left`, `channel_deleted`, `channel_rename`, `channel_archive`, `channel_un_archive`, `channel_history_changed`, `im_created`, `im_open`, `im_close`, `im_marked`, `im_history_changed`, `group_joined`, `group_left`, `group_open`, `group_close`, `group_archive`, `group_un_archive`, `group_rename`, `group_marked`, `group_history_changed`, `file_created`, `file_shared`, `file_un_shared`, `file_public`, `file_private`, `file_change`, `file_deleted`, `file_comment_added`, `file_comment_edited`, `file_comment_deleted`, `pin_added`, `pin_removed`, `presence_change`, `manual_presence_change`, `pref_change`, `user_change`, `team_join`, `star_added`, `star_removed`, `reaction_added`, `reaction_removed`, `emoji_changed`, `commands_changed`, `team_plan_change`, `team_pref_change`, `team_rename`, `team_domain_change`, `email_domain_changed`, `bot_added`, `bot_changed`, `accounts_changed`, `team_migration_started`, `reconnect_url`, `message_sent`, `message_error`, `desktop_notification`", line: 1, column: 18): json: {"type": "goodbye", "source": "gateway_server"}
thread 'main' panicked at 'Err: Could not login and start slack client! Websocket Error: AlreadyClosed', src/slack.rs:176:21
```

According to Slack's API docs:
> Other scenarios where you might encounter the goodbye event are: - reaching the maximum duration of a RTM web socket connection (8 hours) 

I do get these errors approximately 8 hours after last activity (snippet from above logs):
```
2020-08-19 01:46:18,071 INFO
2020-08-19 09:49:34,964 INFO
```

Having `Goodbye` in the `Event` enum will allow users to handle in the `on_event` function. If you're curious about my usage (found [here](https://github.com/jeffrade/slackrypt/blob/e076d6359426cec16bc5f5f239e802094a31a9f2/server/src/main.rs#L26-L27)), it was built from the [example](https://github.com/slack-rs/slack-rs/blob/master/examples/slack_example.rs) and I use `block_on` after wrapping `RtmClient::login_and_run` in an `async` function.