### PR TITLE
Add tls features and require one to be selected

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,8 @@ serde_derive = "1.0.0"
 tungstenite = "0.9.2"
 log = "0.3.7"
 url = "2.1.0"
+
+[features]
+default = ["with_native_tls"]
+with_rustls = ["slack_api/with_rustls"]
+with_native_tls = ["slack_api/with_native_tls"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    let found_tls = cfg!(feature = "with_rustls") || cfg!(feature = "with_native_tls");
+    if !found_tls {
+        panic!(
+            "slack: at least one of 'with_native_tls' or 'with_rustls' features must be enabled"
+        );
+    }
+}


### PR DESCRIPTION
The crate just doesn't work if neither of these features are enabled which causes an error as per #120

so allow choosing which tls but you must choose one, default to native